### PR TITLE
[RFC] GALA-IMPALA: Local gossip with gala agents in ring topology, one per GPU

### DIFF
--- a/third-party/gala/__init__.py
+++ b/third-party/gala/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+from .gala_a2c import GALA_A2C

--- a/third-party/gala/arguments.py
+++ b/third-party/gala/arguments.py
@@ -1,0 +1,165 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+import argparse
+
+import torch
+
+
+def get_args(arg_dict=None):
+    parser = argparse.ArgumentParser(description='RL')
+
+    parser.add_argument(
+        '--sync-freq',
+        type=int,
+        default=0,
+        help='max amount of message staleness for local gossip')
+    parser.add_argument(
+        '--num-learners',
+        type=int,
+        default=1,
+        help='number of learners to stack on device')
+    parser.add_argument(
+        '--num-peers',
+        type=int,
+        default=1,
+        help='number of peers to communicate with in each iteration')
+    parser.add_argument(
+        '--lr',
+        type=float,
+        default=7e-4,
+        help='learning rate (default: 7e-4)')
+    parser.add_argument(
+        '--eps',
+        type=float,
+        default=1e-5,
+        help='RMSprop optimizer epsilon (default: 1e-5)')
+    parser.add_argument(
+        '--alpha',
+        type=float,
+        default=0.99,
+        help='RMSprop optimizer apha (default: 0.99)')
+    parser.add_argument(
+        '--gamma',
+        type=float,
+        default=0.99,
+        help='discount factor for rewards (default: 0.99)')
+    parser.add_argument(
+        '--use-gae',
+        action='store_true',
+        default=False,
+        help='use generalized advantage estimation')
+    parser.add_argument(
+        '--gae-lambda',
+        type=float,
+        default=0.95,
+        help='gae lambda parameter (default: 0.95)')
+    parser.add_argument(
+        '--entropy-coef',
+        type=float,
+        default=0.01,
+        help='entropy term coefficient (default: 0.01)')
+    parser.add_argument(
+        '--value-loss-coef',
+        type=float,
+        default=0.5,
+        help='value loss coefficient (default: 0.5)')
+    parser.add_argument(
+        '--max-grad-norm',
+        type=float,
+        default=0.5,
+        help='max norm of gradients (default: 0.5)')
+    parser.add_argument(
+        '--seed',
+        type=int,
+        default=1,
+        help='random seed (default: 1)')
+    parser.add_argument(
+        '--cuda-deterministic',
+        action='store_true',
+        default=False,
+        help="sets flags for determinism when using CUDA (potentially slow!)")
+    parser.add_argument(
+        '--num-procs-per-learner',
+        type=int,
+        default=16,
+        help='num simulators per learner (default: 16)')
+    parser.add_argument(
+        '--max-steps',
+        type=int,
+        default=int(10e3),
+        help='max episode length (default: 10,000)')
+    parser.add_argument(
+        '--num-steps-per-update',
+        type=int,
+        default=5,
+        help='number of forward steps in A2C (default: 5)')
+    parser.add_argument(
+        '--clip-param',
+        type=float,
+        default=0.2,
+        help='ppo clip parameter (default: 0.2)')
+    parser.add_argument(
+        '--log-interval',
+        type=int,
+        default=10,
+        help='log interval, measured in environment steps (default: 10)')
+    parser.add_argument(
+        '--save-interval',
+        type=int,
+        default=100,
+        help='save interval, measured in environment steps (default: 100)')
+    parser.add_argument(
+        '--num-env-steps',
+        type=int,
+        default=10e6,
+        help='number of total environment steps to train (default: 10e6)')
+    parser.add_argument(
+        '--env-name',
+        default='PongNoFrameskip-v4',
+        help='environment to train on (default: PongNoFrameskip-v4)')
+    parser.add_argument(
+        '--eval-log-dir',
+        default='/tmp/gym/eval/',
+        help='directory to save agent eval-logs (default: /tmp/gym/eval/)')
+    parser.add_argument(
+        '--log-dir',
+        default='/tmp/gym/',
+        help='directory to save agent logs (default: /tmp/gym)')
+    parser.add_argument(
+        '--save-dir',
+        default='./trained_models/',
+        help='directory to save agent logs (default: ./trained_models/)')
+    parser.add_argument(
+        '--cuda-device',
+        type=int,
+        default=0,
+        help='index of cuda device to use')
+    parser.add_argument(
+        '--no-cuda',
+        action='store_true',
+        default=False,
+        help='disables CUDA training')
+    parser.add_argument(
+        '--use-proper-time-limits',
+        action='store_true',
+        default=False,
+        help='compute returns taking into account time limits')
+    parser.add_argument(
+        '--recurrent-policy',
+        action='store_true',
+        default=False,
+        help='use a recurrent policy')
+    parser.add_argument(
+        '--use-linear-lr-decay',
+        action='store_true',
+        default=False,
+        help='use a linear schedule on the learning rate')
+
+    args = parser.parse_args(arg_dict)
+    args.cuda = not args.no_cuda and torch.cuda.is_available()
+
+    return args

--- a/third-party/gala/distributions.py
+++ b/third-party/gala/distributions.py
@@ -1,0 +1,147 @@
+"""
+MIT License
+
+Copyright (c) 2017 Ilya Kostrikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Taken from https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail
+and slightly modified.
+"""
+import torch
+import torch.nn as nn
+
+
+# Necessary for my KFAC implementation.
+class AddBias(nn.Module):
+    def __init__(self, bias):
+        super(AddBias, self).__init__()
+        self._bias = nn.Parameter(bias.unsqueeze(1))
+
+    def forward(self, x):
+        if x.dim() == 2:
+            bias = self._bias.t().view(1, -1)
+        else:
+            bias = self._bias.t().view(1, -1, 1, 1)
+
+        return x + bias
+
+
+def init(module, weight_init, bias_init, gain=1):
+    weight_init(module.weight.data, gain=gain)
+    bias_init(module.bias.data)
+    return module
+
+
+"""
+Modify standard PyTorch distributions so they are compatible with this code.
+"""
+
+#
+# Standardize distribution interfaces
+#
+
+# Categorical
+FixedCategorical = torch.distributions.Categorical
+
+old_sample = FixedCategorical.sample
+FixedCategorical.sample = lambda self: old_sample(self).unsqueeze(-1)
+
+log_prob_cat = FixedCategorical.log_prob
+FixedCategorical.log_probs = lambda self, actions: log_prob_cat(
+    self, actions.squeeze(-1)).view(actions.size(0), -1).sum(-1).unsqueeze(-1)
+
+FixedCategorical.mode = lambda self: self.probs.argmax(dim=-1, keepdim=True)
+
+# Normal
+FixedNormal = torch.distributions.Normal
+
+log_prob_normal = FixedNormal.log_prob
+FixedNormal.log_probs = lambda self, actions: log_prob_normal(
+    self, actions).sum(
+        -1, keepdim=True)
+
+normal_entropy = FixedNormal.entropy
+FixedNormal.entropy = lambda self: normal_entropy(self).sum(-1)
+
+FixedNormal.mode = lambda self: self.mean
+
+# Bernoulli
+FixedBernoulli = torch.distributions.Bernoulli
+
+log_prob_bernoulli = FixedBernoulli.log_prob
+FixedBernoulli.log_probs = lambda self, actions: log_prob_bernoulli(
+    self, actions).view(actions.size(0), -1).sum(-1).unsqueeze(-1)
+
+bernoulli_entropy = FixedBernoulli.entropy
+FixedBernoulli.entropy = lambda self: bernoulli_entropy(self).sum(-1)
+FixedBernoulli.mode = lambda self: torch.gt(self.probs, 0.5).float()
+
+
+class Categorical(nn.Module):
+    def __init__(self, num_inputs, num_outputs):
+        super(Categorical, self).__init__()
+
+        init_ = lambda m: init(
+            m,
+            nn.init.orthogonal_,
+            lambda x: nn.init.constant_(x, 0),
+            gain=0.01)
+
+        self.linear = init_(nn.Linear(num_inputs, num_outputs))
+
+    def forward(self, x):
+        x = self.linear(x)
+        return FixedCategorical(logits=x)
+
+
+class DiagGaussian(nn.Module):
+    def __init__(self, num_inputs, num_outputs):
+        super(DiagGaussian, self).__init__()
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0))
+
+        self.fc_mean = init_(nn.Linear(num_inputs, num_outputs))
+        self.logstd = AddBias(torch.zeros(num_outputs))
+
+    def forward(self, x):
+        action_mean = self.fc_mean(x)
+
+        #  An ugly hack for my KFAC implementation.
+        zeros = torch.zeros(action_mean.size())
+        if x.is_cuda:
+            zeros = zeros.cuda()
+
+        action_logstd = self.logstd(zeros)
+        return FixedNormal(action_mean, action_logstd.exp())
+
+
+class Bernoulli(nn.Module):
+    def __init__(self, num_inputs, num_outputs):
+        super(Bernoulli, self).__init__()
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0))
+
+        self.linear = init_(nn.Linear(num_inputs, num_outputs))
+
+    def forward(self, x):
+        x = self.linear(x)
+        return FixedBernoulli(logits=x)

--- a/third-party/gala/envs.py
+++ b/third-party/gala/envs.py
@@ -1,0 +1,271 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+"""
+MIT License
+
+Copyright (c) 2017 Ilya Kostrikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Modified from https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail
+"""
+
+import os
+
+import gym
+import numpy as np
+import torch
+from gym.spaces.box import Box
+
+from baselines import bench
+from baselines.common.atari_wrappers import make_atari, wrap_deepmind
+from baselines.common.vec_env import VecEnvWrapper
+from baselines.common.vec_env.dummy_vec_env import DummyVecEnv
+from baselines.common.vec_env.shmem_vec_env import ShmemVecEnv
+from baselines.common.vec_env.vec_normalize import \
+    VecNormalize as VecNormalize_
+
+try:
+    import dm_control2gym
+except ImportError:
+    pass
+
+def make_env(env_id, seed, rank, log_dir, allow_early_resets, signature='',
+             max_steps=None):
+    def _thunk():
+        if env_id.startswith("dm"):
+            _, domain, task = env_id.split('.')
+            env = dm_control2gym.make(domain_name=domain, task_name=task)
+        else:
+            env = gym.make(env_id)
+
+        is_atari = hasattr(gym.envs, 'atari') and isinstance(
+            env.unwrapped, gym.envs.atari.atari_env.AtariEnv)
+        if is_atari:
+            env = make_atari(env_id, max_steps)
+
+        env.seed(seed + rank)
+
+        obs_shape = env.observation_space.shape
+
+        if str(env.__class__.__name__).find('TimeLimit') >= 0:
+            env = TimeLimitMask(env)
+
+        if log_dir is not None:
+            env = bench.Monitor(
+                env,
+                os.path.join(log_dir, str(rank) + signature),
+                allow_early_resets=allow_early_resets)
+
+        if is_atari:
+            if len(env.observation_space.shape) == 3:
+                env = wrap_deepmind(env)
+        elif len(env.observation_space.shape) == 3:
+            raise NotImplementedError(
+                "CNN models work only for atari,\n"
+                "please use a custom wrapper for a custom pixel input env.\n"
+                "See wrap_deepmind for an example.")
+
+        # If the input has shape (W,H,3), wrap for PyTorch convolutions
+        obs_shape = env.observation_space.shape
+        if len(obs_shape) == 3 and obs_shape[2] in [1, 3]:
+            env = TransposeImage(env, op=[2, 0, 1])
+
+        return env
+
+    return _thunk
+
+
+def make_vec_envs(env_name, seed, num_processes, gamma, log_dir, device,
+                  allow_early_resets, num_frame_stack=None, rank=0,
+                  signature='', max_steps=None):
+    print('log-dir', log_dir)
+    envs = [
+        make_env(env_name, seed, (rank * num_processes) + i, log_dir,
+                 allow_early_resets, signature, max_steps)
+        for i in range(num_processes)
+    ]
+
+    if len(envs) > 1:
+        envs = ShmemVecEnv(envs)
+    else:
+        envs = DummyVecEnv(envs)
+
+    if len(envs.observation_space.shape) == 1:
+        if gamma is None:
+            envs = VecNormalize(envs, ret=False)
+        else:
+            envs = VecNormalize(envs, gamma=gamma)
+
+    envs = VecPyTorch(envs, device)
+
+    if num_frame_stack is not None:
+        envs = VecPyTorchFrameStack(envs, num_frame_stack, device)
+    elif len(envs.observation_space.shape) == 3:
+        envs = VecPyTorchFrameStack(envs, 4, device)
+
+    return envs
+
+
+# Checks whether done was caused my timit limits or not
+class TimeLimitMask(gym.Wrapper):
+    def step(self, action):
+        obs, rew, done, info = self.env.step(action)
+        if done and self.env._max_episode_steps == self.env._elapsed_steps:
+            info['bad_transition'] = True
+
+        return obs, rew, done, info
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
+
+
+# Can be used to test recurrent policies for Reacher-v2
+class MaskGoal(gym.ObservationWrapper):
+    def observation(self, observation):
+        if self.env._elapsed_steps > 0:
+            observation[-2:0] = 0
+        return observation
+
+
+class TransposeObs(gym.ObservationWrapper):
+    def __init__(self, env=None):
+        """
+        Transpose observation space (base class)
+        """
+        super(TransposeObs, self).__init__(env)
+
+
+class TransposeImage(TransposeObs):
+    def __init__(self, env=None, op=[2, 0, 1]):
+        """
+        Transpose observation space for images
+        """
+        super(TransposeImage, self).__init__(env)
+        assert len(op) == 3, f"Error: Operation, {str(op)}, must be dim3"
+        self.op = op
+        obs_shape = self.observation_space.shape
+        self.observation_space = Box(
+            self.observation_space.low[0, 0, 0],
+            self.observation_space.high[0, 0, 0], [
+                obs_shape[self.op[0]], obs_shape[self.op[1]],
+                obs_shape[self.op[2]]
+            ],
+            dtype=self.observation_space.dtype)
+
+    def observation(self, ob):
+        return ob.transpose(self.op[0], self.op[1], self.op[2])
+
+
+class VecPyTorch(VecEnvWrapper):
+    def __init__(self, venv, device):
+        """Return only every `skip`-th frame"""
+        super(VecPyTorch, self).__init__(venv)
+        self.device = device
+        # TODO: Fix data types
+
+    def reset(self):
+        obs = self.venv.reset()
+        obs = torch.from_numpy(obs).float().to(self.device)
+        return obs
+
+    def step_async(self, actions):
+        if isinstance(actions, torch.LongTensor):
+            # Squeeze the dimension for discrete actions
+            actions = actions.squeeze(1)
+        actions = actions.cpu().numpy()
+        self.venv.step_async(actions)
+
+    def step_wait(self):
+        obs, reward, done, info = self.venv.step_wait()
+        obs = torch.from_numpy(obs).float().to(self.device)
+        reward = torch.from_numpy(reward).unsqueeze(dim=1).float()
+        return obs, reward, done, info
+
+
+class VecNormalize(VecNormalize_):
+    def __init__(self, *args, **kwargs):
+        super(VecNormalize, self).__init__(*args, **kwargs)
+        self.training = True
+
+    def _obfilt(self, obs, update=True):
+        if self.ob_rms:
+            if self.training and update:
+                self.ob_rms.update(obs)
+            obs = np.clip((obs - self.ob_rms.mean) /
+                          np.sqrt(self.ob_rms.var + self.epsilon),
+                          -self.clipob, self.clipob)
+            return obs
+        else:
+            return obs
+
+    def train(self):
+        self.training = True
+
+    def eval(self):
+        self.training = False
+
+
+# Derived from
+# https://github.com/openai/baselines/blob/master/baselines/common/vec_env/vec_frame_stack.py
+class VecPyTorchFrameStack(VecEnvWrapper):
+    def __init__(self, venv, nstack, device=None):
+        self.venv = venv
+        self.nstack = nstack
+
+        wos = venv.observation_space  # wrapped ob space
+        self.shape_dim0 = wos.shape[0]
+
+        low = np.repeat(wos.low, self.nstack, axis=0)
+        high = np.repeat(wos.high, self.nstack, axis=0)
+
+        if device is None:
+            device = torch.device('cpu')
+        self.stacked_obs = torch.zeros((venv.num_envs, ) +
+                                       low.shape).to(device)
+
+        observation_space = gym.spaces.Box(
+            low=low, high=high, dtype=venv.observation_space.dtype)
+        VecEnvWrapper.__init__(self, venv, observation_space=observation_space)
+
+    def step_wait(self):
+        obs, rews, news, infos = self.venv.step_wait()
+        self.stacked_obs[:, :-self.shape_dim0] = \
+            self.stacked_obs[:, self.shape_dim0:]
+        for (i, new) in enumerate(news):
+            if new:
+                self.stacked_obs[i] = 0
+        self.stacked_obs[:, -self.shape_dim0:] = obs
+        return self.stacked_obs, rews, news, infos
+
+    def reset(self):
+        obs = self.venv.reset()
+        if torch.backends.cudnn.deterministic:
+            self.stacked_obs = torch.zeros(self.stacked_obs.shape)
+        else:
+            self.stacked_obs.zero_()
+        self.stacked_obs[:, -self.shape_dim0:] = obs
+        return self.stacked_obs
+
+    def close(self):
+        self.venv.close()

--- a/third-party/gala/gala_a2c.py
+++ b/third-party/gala/gala_a2c.py
@@ -1,0 +1,66 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+""" GALA-A2C agent """
+
+import torch.nn as nn
+import torch.optim as optim
+
+
+class GALA_A2C():
+
+    def __init__(self, actor_critic, value_loss_coef, entropy_coef, lr=None,
+                 eps=None, alpha=None, max_grad_norm=None,
+                 rank=0, gossip_buffer=None):
+        """ GALA_A2C """
+
+        self.rank = rank
+        self.gossip_buffer = gossip_buffer
+        self.actor_critic = actor_critic
+
+        self.value_loss_coef = value_loss_coef
+        self.entropy_coef = entropy_coef
+
+        self.max_grad_norm = max_grad_norm
+
+        self.optimizer = optim.RMSprop(
+            actor_critic.parameters(), lr, eps=eps, alpha=alpha)
+
+    def update(self, rollouts):
+        obs_shape = rollouts.obs.size()[2:]
+        action_shape = rollouts.actions.size()[-1]
+        num_steps, num_processes, _ = rollouts.rewards.size()
+
+        values, action_log_probs, dist_entropy, _ = self.actor_critic.evaluate_actions(
+            rollouts.obs[:-1].view(-1, *obs_shape),
+            rollouts.recurrent_hidden_states[0].view(
+                -1, self.actor_critic.recurrent_hidden_state_size),
+            rollouts.masks[:-1].view(-1, 1),
+            rollouts.actions.view(-1, action_shape))
+
+        values = values.view(num_steps, num_processes, 1)
+        action_log_probs = action_log_probs.view(num_steps, num_processes, 1)
+
+        advantages = rollouts.returns[:-1] - values
+        value_loss = advantages.pow(2).mean()
+
+        action_loss = -(advantages.detach() * action_log_probs).mean()
+
+        self.optimizer.zero_grad()
+        (value_loss * self.value_loss_coef + action_loss -
+         dist_entropy * self.entropy_coef).backward()
+
+        nn.utils.clip_grad_norm_(self.actor_critic.parameters(),
+                                 self.max_grad_norm)
+
+        self.optimizer.step()
+
+        # Local-Gossip
+        if self.gossip_buffer is not None:
+            self.gossip_buffer.write_message(self.rank, self.actor_critic)
+            self.gossip_buffer.aggregate_message(self.rank, self.actor_critic)
+
+        return value_loss.item(), action_loss.item(), dist_entropy.item()

--- a/third-party/gala/gpu_gossip_buffer.py
+++ b/third-party/gala/gpu_gossip_buffer.py
@@ -1,0 +1,160 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+"""
+Gossip Buffer
+
+:author: Mido Assran
+:description: Class defines a shared-memory Gossip-Buffer, which allows
+    multi-processed asynchronous agents on the same machine to communicate
+    tensors to on one-another
+"""
+
+import copy
+import torch
+
+
+class GossipBuffer():
+
+    def __init__(self, topology, model, buffer_locks, read_events,
+                 write_events, sync_list, sync_freq=0):
+        """ GossipBuffer """
+
+        self.topology = topology
+        self.num_learners = len(topology)
+        self.sync_list = sync_list
+        self.sync_freq = sync_freq
+
+        # Initialize message buffer (4-item object):
+        # [0] -> Msg-Tensor
+        # [1] -> Events recording peers that have read the message
+        # [2] -> Events recording peer that has written the message
+        # [3] -> Lock for safe access of Msg-Tensor
+        self.msg_buffer = []
+        for rank in range(self.num_learners):
+            msg = copy.deepcopy(model)
+            msg.share_memory()
+            r_events = read_events[rank]
+            w_events = write_events[rank]
+            lock = buffer_locks[rank]
+            self.msg_buffer.append([msg, r_events, w_events, lock])
+
+        # Initialize each Read-Buffer as 'read'
+        for msg_buffer in self.msg_buffer:
+            read_event_list = msg_buffer[1]
+            for event in read_event_list:
+                event.set()
+
+    def write_message(self, rank, model, rotate=False):
+        """
+        Write agent 'rank's 'model' to a local 'boradcast buffer' that will be
+        read by the out-neighbours defined in 'self.topology'.
+
+        :param rank: Agent's rank in multi-agent graph topology
+        :param model: Agent's torch neural network model
+        :param rotate: Whether to alternate peers in graph topology
+
+        Agents should only write to their own broadcast buffer:
+            i.e., ensure 'model' belongs to agent 'rank'
+        WARNING: setting rotate=True with sync_freq > 1 not currently supported
+        """
+        with torch.no_grad():
+
+            # Get local broadcast-buffer
+            msg_buffer = self.msg_buffer[rank]
+            broadcast_buffer = msg_buffer[0]
+            read_event_list = msg_buffer[1]
+            write_event_list = msg_buffer[2]
+            lock = msg_buffer[3]
+
+            # Check if out-peers finished reading our last message
+            out_peers, _ = self.topology[rank].get_peers()
+            read_complete = True
+            for peer in out_peers:
+                if not read_event_list[peer].is_set():
+                    read_complete = False
+                    break
+
+            # If peers done reading our last message, wait and clear events
+            if read_complete:
+                for peer in out_peers:
+                    read_event = read_event_list[peer]
+                    read_event.wait()
+                    read_event.clear()
+            # If not done reading, cannot write another message right now
+            else:
+                return
+
+            # Update broadcast-buffer with new message
+            # -- flatten params and multiply by mixing-weight
+            num_peers = self.topology[rank].peers_per_itr
+            with lock:
+                for bp, p in zip(broadcast_buffer.parameters(),
+                                 model.parameters()):
+                    bp.data.copy_(p)
+                    bp.data.div_(num_peers + 1)
+                # -- mark message as 'written'
+                out_peers, _ = self.topology[rank].get_peers(rotate)
+                torch.cuda.current_stream().synchronize()
+                for peer in out_peers:
+                    write_event_list[peer].set()
+
+    def aggregate_message(self, rank, model):
+        """
+        Average messages with local model:
+        Average all in-neighbours' (defined in 'self.topology') parameters with
+        agent 'rank's 'model' and copy the result into 'model'.
+
+        Agents should only aggregate messages into their own model:
+            i.e., ensure 'model belongs to agent 'rank'
+        """
+        with torch.no_grad():
+
+            # Check if in-peers finished writing messages to broadcast buffers
+            _, in_peers = self.topology[rank].get_peers()
+            write_complete = True
+            for peer in in_peers:
+                peer_buffer = self.msg_buffer[peer]
+                write_event = peer_buffer[2][rank]
+                if not write_event.is_set():
+                    write_complete = False
+                    break
+
+            # Check if any messages are excessively stale
+            stale_assert = self.sync_list[rank] >= self.sync_freq
+
+            # If peers done writing or message too stale, wait and clear events
+            if write_complete or stale_assert:
+                for peer in in_peers:
+                    peer_buffer = self.msg_buffer[peer]
+                    write_event = peer_buffer[2][rank]
+                    write_event.wait()
+                    write_event.clear()
+                    self.sync_list[rank] = 0
+            # Not done writing, but staleness is still tolerable
+            else:
+                self.sync_list[rank] += 1
+                print('%s: staleness %s' % (rank, self.sync_list[rank]))
+                return
+
+            # Lazy-mixing of local params
+            num_peers = self.topology[rank].peers_per_itr
+            for p in model.parameters():
+                p.data.div_(num_peers + 1)
+
+            # Aggregate received messages
+            for peer in in_peers:
+                peer_buffer = self.msg_buffer[peer]
+                lock = peer_buffer[3]
+                with lock:
+                    # Read message and update 'params'
+                    peer_msg = peer_buffer[0]
+                    for p, bp in zip(model.parameters(),
+                                     peer_msg.parameters()):
+                        p.data.add_(bp.to(p.device, non_blocking=True))
+                    torch.cuda.current_stream().synchronize()
+                    # Mark message as 'read'
+                    peer_buffer[1][rank].set()

--- a/third-party/gala/graph_manager.py
+++ b/third-party/gala/graph_manager.py
@@ -1,0 +1,264 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+"""
+Graph Manager Class
+
+:author: Mido Assran
+:description: Class provides an API for loading different peer-to-peer
+    communication topologies, and cycling through peers.
+"""
+
+from math import log as mlog
+
+
+class GraphManager(object):
+
+    def __init__(self, rank, world_size, peers_per_itr=1):
+        assert int(peers_per_itr) >= 1
+        self.rank = rank
+        self.world_size = world_size
+        self.phone_book = self._make_graph()
+        self._peers_per_itr = peers_per_itr
+        self._group_indices = [i for i in range(peers_per_itr)]
+
+    @property
+    def peers_per_itr(self):
+        return self._peers_per_itr
+
+    @peers_per_itr.setter
+    def peers_per_itr(self, v):
+        self._peers_per_itr = v
+        # set group-indices attr. --- point to out-peers in phone-book
+        self._group_indices = [i for i in range(v)]
+
+    def _make_graph(self):
+        """
+        Returns a nested list of peers; the outer-list is indexed by rank,
+        the inner list denotes the set of peers that 'rank' can send
+        messages to at any point in time
+        """
+        raise NotImplementedError
+
+    def is_regular_graph(self):
+        """ Whether each node has the same number of in-peers as out-peers """
+        raise NotImplementedError
+
+    def is_bipartite_graph(self):
+        """ Whether graph is bipartite or not """
+        raise NotImplementedError
+
+    def is_passive(self, rank=None):
+        """ Whether 'rank' is a passive node or not """
+        raise NotImplementedError
+
+    def is_dynamic_graph(self, graph_type=None):
+        """ Whether the graph-type is dynamic (as opposed to static) """
+        raise NotImplementedError
+
+    def get_peers(self, rotate=False):
+        """ Returns the out and in-peers corresponding to 'self.rank' """
+        # cycle through in- and out-peers by updating group-index
+        if rotate:
+            self._rotate_group_indices()
+
+        # get out- and in-peers using new group-indices
+        out_peers, in_peers = [], []
+        for group_index in self._group_indices:
+            out_peers.append(self.phone_book[self.rank][group_index])
+            for rank, peers in enumerate(self.phone_book):
+                if rank == self.rank:
+                    continue
+                if self.rank == peers[group_index]:
+                    in_peers.append(rank)
+        return out_peers, in_peers
+
+    def _rotate_group_indices(self):
+        """ Incerement group indices to point to the next out-peer """
+        increment = self.peers_per_itr
+        for i, group_index in enumerate(self._group_indices):
+            self._group_indices[i] = int((group_index + increment)
+                                         % len(self.phone_book[self.rank]))
+
+    def _rotate_forward(self, r, p):
+        """ Helper function returns peer that is p hops ahead of r """
+        return (r + p) % self.world_size
+
+    def _rotate_backward(self, r, p):
+        """ Helper function returns peer that is p hops behind r """
+        temp = r
+        for _ in range(p):
+            temp -= 1
+            if temp < 0:
+                temp = self.world_size - 1
+        return temp
+
+
+class DynamicDirectedExponentialGraph(GraphManager):
+
+    def _make_graph(self):
+        phone_book = [[] for _ in range(self.world_size)]
+        for rank in range(self.world_size):
+            group = phone_book[rank]
+            for i in range(0, int(mlog(self.world_size - 1, 2)) + 1):
+                f_peer = self._rotate_forward(rank, 2 ** i)
+                if f_peer not in group:
+                    group.append(f_peer)
+                b_peer = self._rotate_backward(rank, 2 ** i)
+                if b_peer not in group:
+                    group.append(b_peer)
+        return phone_book
+
+    def is_regular_graph(self): return True
+
+    def is_bipartite_graph(self): return False
+
+    def is_passive(self, rank=None): return False
+
+    def is_dynamic_graph(self, graph_type=None): return True
+
+
+class DynamicBipartiteExponentialGraph(GraphManager):
+
+    def _make_graph(self):
+        phone_book = [[] for _ in range(self.world_size)]
+        for rank in range(self.world_size):
+            group = phone_book[rank]
+            for i in range(0, int(mlog(self.world_size - 1, 2)) + 1):
+                if i == 0:
+                    f_peer = self._rotate_forward(rank, 1)
+                    b_peer = self._rotate_backward(rank, 1)
+                else:
+                    f_peer = self._rotate_forward(rank, 1 + 2 ** i)
+                    b_peer = self._rotate_backward(rank, 1 + 2 ** i)
+                # create directory for non-passive peers
+                if not self.is_passive(rank) and (
+                   self.is_passive(f_peer) and self.is_passive(b_peer)):
+                    if f_peer not in group:
+                        group.append(f_peer)  # forward peer...
+                    if b_peer not in group:
+                        group.append(b_peer)  # then backward peer
+                # create directory for passive peers
+                elif self.is_passive(rank) and (
+                   not (self.is_passive(f_peer) or self.is_passive(b_peer))):
+                    if b_peer not in group:
+                        group.append(b_peer)  # backward peer...
+                    if f_peer not in group:
+                        group.append(f_peer)  # then forward peer
+        return phone_book
+
+    def is_regular_graph(self): return True
+
+    def is_bipartite_graph(self): return True
+
+    def is_passive(self, rank=None):
+        rank = self.rank if rank is None else rank
+        return (rank % 2) == 0
+
+    def is_dynamic_graph(self, graph_type=None): return True
+
+
+class DynamicDirectedLinearGraph(GraphManager):
+
+    def _make_graph(self):
+        phone_book = [[] for _ in range(self.world_size)]
+        for rank in range(self.world_size):
+            group = phone_book[rank]
+            for i in range(1, self.world_size):
+                if i % 2 == 0:
+                    continue
+                f_peer = self._rotate_forward(rank, i)
+                if f_peer not in group:
+                    group.append(f_peer)
+                b_peer = self._rotate_backward(rank, i)
+                if b_peer not in group:
+                    group.append(b_peer)
+        return phone_book
+
+    def is_regular_graph(self): return True
+
+    def is_bipartite_graph(self): return False
+
+    def is_passive(self, rank=None): return False
+
+    def is_dynamic_graph(self, graph_type=None): return True
+
+
+class DynamicBipartiteLinearGraph(GraphManager):
+
+    def _make_graph(self):
+        phone_book = [[] for _ in range(self.world_size)]
+        for rank in range(self.world_size):
+            group = phone_book[rank]
+            for i in range(1, self.world_size):
+                f_peer = self._rotate_forward(rank, i)
+                b_peer = self._rotate_backward(rank, i)
+                # create directory for non-passive peers
+                if not self.is_passive(rank) and (
+                   self.is_passive(f_peer) and self.is_passive(b_peer)):
+                    if f_peer not in group:
+                        group.append(f_peer)  # forward peer...
+                    if b_peer not in group:
+                        group.append(b_peer)  # then backward peer
+                # create directory for passive peers
+                elif self.is_passive(rank) and (
+                   not (self.is_passive(f_peer) or self.is_passive(b_peer))):
+                    if b_peer not in group:
+                        group.append(b_peer)  # backward peer...
+                    if f_peer not in group:
+                        group.append(f_peer)  # then forward peer
+        return phone_book
+
+    def is_regular_graph(self): return True
+
+    def is_bipartite_graph(self): return True
+
+    def is_passive(self, rank=None):
+        rank = self.rank if rank is None else rank
+        return (rank % 2) == 0
+
+    def is_dynamic_graph(self, graph_type=None): return True
+
+
+class StaticDirectedLinearGraph(GraphManager):
+
+    def _make_graph(self):
+        phone_book = [[] for _ in range(self.world_size)]
+        for rank in range(self.world_size):
+            group = phone_book[rank]
+            f_peer = self._rotate_forward(rank, 1)
+            if f_peer not in group:
+                group.append(f_peer)
+        return phone_book
+
+    def is_regular_graph(self): return True
+
+    def is_bipartite_graph(self): return False
+
+    def is_passive(self, rank=None): return False
+
+    def is_dynamic_graph(self, graph_type=None): return False
+
+
+class FullyConnectedGraph(GraphManager):
+
+    def _make_graph(self):
+        phone_book = [[] for _ in range(self.world_size)]
+        for rank in range(self.world_size):
+            group = phone_book[rank]
+            for i in range(1, self.world_size):
+                f_peer = self._rotate_forward(rank, i)
+                if f_peer not in group and f_peer != rank:
+                    group.append(f_peer)
+        return phone_book
+
+    def is_regular_graph(self): return True
+
+    def is_bipartite_graph(self): return False
+
+    def is_passive(self, rank=None): return False
+
+    def is_dynamic_graph(self, graph_type=None): return False

--- a/third-party/gala/model.py
+++ b/third-party/gala/model.py
@@ -1,0 +1,272 @@
+"""
+MIT License
+
+Copyright (c) 2017 Ilya Kostrikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Taken from https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail
+and slightly modified.
+"""
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from gala.distributions import Bernoulli, Categorical, DiagGaussian
+
+
+def init(module, weight_init, bias_init, gain=1):
+    weight_init(module.weight.data, gain=gain)
+    bias_init(module.bias.data)
+    return module
+
+
+class Flatten(nn.Module):
+    def forward(self, x):
+        return x.view(x.size(0), -1)
+
+
+class Policy(nn.Module):
+    def __init__(self, obs_shape, action_space=None, base=None, base_kwargs=None, env_name=None):
+        super(Policy, self).__init__()
+        if base_kwargs is None:
+            base_kwargs = {}
+        if base is None:
+            if len(obs_shape) == 3:
+                base = CNNBase
+            elif len(obs_shape) == 1:
+                base = MLPBase
+            else:
+                raise NotImplementedError
+
+        self.base = base(obs_shape[0], **base_kwargs)
+
+        if action_space is None:
+            game = env_name[:env_name.find('NoFrameskip')]
+            num_actions = {
+                'BeamRider': 9,
+                'Breakout': 4,
+                'Pong': 6,
+                'Qbert': 6,
+                'Seaquest': 18,
+                'SpaceInvaders': 6,
+            }
+            num_outputs = num_actions[game]
+            self.dist = Categorical(self.base.output_size, num_outputs)
+        elif action_space.__class__.__name__ == "Discrete":
+            num_outputs = action_space.n
+            self.dist = Categorical(self.base.output_size, num_outputs)
+        elif action_space.__class__.__name__ == "Box":
+            num_outputs = action_space.shape[0]
+            self.dist = DiagGaussian(self.base.output_size, num_outputs)
+        elif action_space.__class__.__name__ == "MultiBinary":
+            num_outputs = action_space.shape[0]
+            self.dist = Bernoulli(self.base.output_size, num_outputs)
+        else:
+            raise NotImplementedError
+
+    @property
+    def is_recurrent(self):
+        return self.base.is_recurrent
+
+    @property
+    def recurrent_hidden_state_size(self):
+        """Size of rnn_hx."""
+        return self.base.recurrent_hidden_state_size
+
+    def forward(self, inputs, rnn_hxs, masks):
+        raise NotImplementedError
+
+    def act(self, inputs, rnn_hxs, masks, deterministic=False):
+        value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
+        dist = self.dist(actor_features)
+
+        if deterministic:
+            action = dist.mode()
+        else:
+            action = dist.sample()
+
+        action_log_probs = dist.log_probs(action)
+        dist_entropy = dist.entropy().mean()
+
+        return value, action, action_log_probs, rnn_hxs
+
+    def get_value(self, inputs, rnn_hxs, masks):
+        value, _, _ = self.base(inputs, rnn_hxs, masks)
+        return value
+
+    def evaluate_actions(self, inputs, rnn_hxs, masks, action):
+        value, actor_features, rnn_hxs = self.base(inputs, rnn_hxs, masks)
+        dist = self.dist(actor_features)
+
+        action_log_probs = dist.log_probs(action)
+        dist_entropy = dist.entropy().mean()
+
+        return value, action_log_probs, dist_entropy, rnn_hxs
+
+
+class NNBase(nn.Module):
+    def __init__(self, recurrent, recurrent_input_size, hidden_size):
+        super(NNBase, self).__init__()
+
+        self._hidden_size = hidden_size
+        self._recurrent = recurrent
+
+        if recurrent:
+            self.gru = nn.GRU(recurrent_input_size, hidden_size)
+            for name, param in self.gru.named_parameters():
+                if 'bias' in name:
+                    nn.init.constant_(param, 0)
+                elif 'weight' in name:
+                    nn.init.orthogonal_(param)
+
+    @property
+    def is_recurrent(self):
+        return self._recurrent
+
+    @property
+    def recurrent_hidden_state_size(self):
+        if self._recurrent:
+            return self._hidden_size
+        return 1
+
+    @property
+    def output_size(self):
+        return self._hidden_size
+
+    def _forward_gru(self, x, hxs, masks):
+        if x.size(0) == hxs.size(0):
+            x, hxs = self.gru(x.unsqueeze(0), (hxs * masks).unsqueeze(0))
+            x = x.squeeze(0)
+            hxs = hxs.squeeze(0)
+        else:
+            # x is a (T, N, -1) tensor that has been flatten to (T * N, -1)
+            N = hxs.size(0)
+            T = int(x.size(0) / N)
+
+            # unflatten
+            x = x.view(T, N, x.size(1))
+
+            # Same deal with masks
+            masks = masks.view(T, N)
+
+            # Let's figure out which steps in the sequence have a zero for any agent
+            # We will always assume t=0 has a zero in it as that makes the logic cleaner
+            has_zeros = ((masks[1:] == 0.0) \
+                            .any(dim=-1)
+                            .nonzero()
+                            .squeeze()
+                            .cpu())
+
+            # +1 to correct the masks[1:]
+            if has_zeros.dim() == 0:
+                # Deal with scalar
+                has_zeros = [has_zeros.item() + 1]
+            else:
+                has_zeros = (has_zeros + 1).numpy().tolist()
+
+            # add t=0 and t=T to the list
+            has_zeros = [0] + has_zeros + [T]
+
+            hxs = hxs.unsqueeze(0)
+            outputs = []
+            for i in range(len(has_zeros) - 1):
+                # We can now process steps that don't have any zeros in masks together!
+                # This is much faster
+                start_idx = has_zeros[i]
+                end_idx = has_zeros[i + 1]
+
+                rnn_scores, hxs = self.gru(
+                    x[start_idx:end_idx],
+                    hxs * masks[start_idx].view(1, -1, 1))
+
+                outputs.append(rnn_scores)
+
+            # assert len(outputs) == T
+            # x is a (T, N, -1) tensor
+            x = torch.cat(outputs, dim=0)
+            # flatten
+            x = x.view(T * N, -1)
+            hxs = hxs.squeeze(0)
+
+        return x, hxs
+
+
+class CNNBase(NNBase):
+    def __init__(self, num_inputs, recurrent=False, hidden_size=512):
+        super(CNNBase, self).__init__(recurrent, hidden_size, hidden_size)
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0), nn.init.calculate_gain('relu'))
+
+        self.main = nn.Sequential(
+            init_(nn.Conv2d(num_inputs, 32, 8, stride=4)), nn.ReLU(),
+            init_(nn.Conv2d(32, 64, 4, stride=2)), nn.ReLU(),
+            init_(nn.Conv2d(64, 32, 3, stride=1)), nn.ReLU(), Flatten(),
+            init_(nn.Linear(32 * 7 * 7, hidden_size)), nn.ReLU())
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0))
+
+        self.critic_linear = init_(nn.Linear(hidden_size, 1))
+
+        self.train()
+
+    def forward(self, inputs, rnn_hxs, masks):
+        x = self.main(inputs / 255.0)
+
+        if self.is_recurrent:
+            x, rnn_hxs = self._forward_gru(x, rnn_hxs, masks)
+
+        return self.critic_linear(x), x, rnn_hxs
+
+
+class MLPBase(NNBase):
+    def __init__(self, num_inputs, recurrent=False, hidden_size=64):
+        super(MLPBase, self).__init__(recurrent, num_inputs, hidden_size)
+
+        if recurrent:
+            num_inputs = hidden_size
+
+        init_ = lambda m: init(m, nn.init.orthogonal_, lambda x: nn.init.
+                               constant_(x, 0), np.sqrt(2))
+
+        self.actor = nn.Sequential(
+            init_(nn.Linear(num_inputs, hidden_size)), nn.Tanh(),
+            init_(nn.Linear(hidden_size, hidden_size)), nn.Tanh())
+
+        self.critic = nn.Sequential(
+            init_(nn.Linear(num_inputs, hidden_size)), nn.Tanh(),
+            init_(nn.Linear(hidden_size, hidden_size)), nn.Tanh())
+
+        self.critic_linear = init_(nn.Linear(hidden_size, 1))
+
+        self.train()
+
+    def forward(self, inputs, rnn_hxs, masks):
+        x = inputs
+
+        if self.is_recurrent:
+            x, rnn_hxs = self._forward_gru(x, rnn_hxs, masks)
+
+        hidden_critic = self.critic(x)
+        hidden_actor = self.actor(x)
+
+        return self.critic_linear(hidden_critic), hidden_actor, rnn_hxs

--- a/third-party/gala/storage.py
+++ b/third-party/gala/storage.py
@@ -1,0 +1,228 @@
+"""
+MIT License
+
+Copyright (c) 2017 Ilya Kostrikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Taken from https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail
+"""
+
+import torch
+from torch.utils.data.sampler import BatchSampler, SubsetRandomSampler
+
+
+def _flatten_helper(T, N, _tensor):
+    return _tensor.view(T * N, *_tensor.size()[2:])
+
+
+class RolloutStorage(object):
+    def __init__(self, num_steps, num_processes, obs_shape, action_space,
+                 recurrent_hidden_state_size):
+        self.obs = torch.zeros(num_steps + 1, num_processes, *obs_shape)
+        self.recurrent_hidden_states = torch.zeros(
+            num_steps + 1, num_processes, recurrent_hidden_state_size)
+        self.rewards = torch.zeros(num_steps, num_processes, 1)
+        self.value_preds = torch.zeros(num_steps + 1, num_processes, 1)
+        self.returns = torch.zeros(num_steps + 1, num_processes, 1)
+        self.action_log_probs = torch.zeros(num_steps, num_processes, 1)
+        if action_space.__class__.__name__ == 'Discrete':
+            action_shape = 1
+        else:
+            action_shape = action_space.shape[0]
+        self.actions = torch.zeros(num_steps, num_processes, action_shape)
+        if action_space.__class__.__name__ == 'Discrete':
+            self.actions = self.actions.long()
+        self.masks = torch.ones(num_steps + 1, num_processes, 1)
+
+        # Masks that indicate whether it's a true terminal state
+        # or time limit end state
+        self.bad_masks = torch.ones(num_steps + 1, num_processes, 1)
+
+        self.num_steps = num_steps
+        self.step = 0
+
+    def to(self, device):
+        self.obs = self.obs.to(device)
+        self.recurrent_hidden_states = self.recurrent_hidden_states.to(device)
+        self.rewards = self.rewards.to(device)
+        self.value_preds = self.value_preds.to(device)
+        self.returns = self.returns.to(device)
+        self.action_log_probs = self.action_log_probs.to(device)
+        self.actions = self.actions.to(device)
+        self.masks = self.masks.to(device)
+        self.bad_masks = self.bad_masks.to(device)
+
+    def insert(self, obs, recurrent_hidden_states, actions, action_log_probs,
+               value_preds, rewards, masks, bad_masks):
+        self.obs[self.step + 1].copy_(obs)
+        self.recurrent_hidden_states[self.step +
+                                     1].copy_(recurrent_hidden_states)
+        self.actions[self.step].copy_(actions)
+        self.action_log_probs[self.step].copy_(action_log_probs)
+        self.value_preds[self.step].copy_(value_preds)
+        self.rewards[self.step].copy_(rewards)
+        self.masks[self.step + 1].copy_(masks)
+        self.bad_masks[self.step + 1].copy_(bad_masks)
+
+        self.step = (self.step + 1) % self.num_steps
+
+    def after_update(self):
+        self.obs[0].copy_(self.obs[-1])
+        self.recurrent_hidden_states[0].copy_(self.recurrent_hidden_states[-1])
+        self.masks[0].copy_(self.masks[-1])
+        self.bad_masks[0].copy_(self.bad_masks[-1])
+
+    def compute_returns(self,
+                        next_value,
+                        use_gae,
+                        gamma,
+                        gae_lambda,
+                        use_proper_time_limits=True):
+        if use_proper_time_limits:
+            if use_gae:
+                self.value_preds[-1] = next_value
+                gae = 0
+                for step in reversed(range(self.rewards.size(0))):
+                    delta = self.rewards[step] + gamma * self.value_preds[
+                        step + 1] * self.masks[step +
+                                               1] - self.value_preds[step]
+                    gae = delta + gamma * gae_lambda * self.masks[step +
+                                                                  1] * gae
+                    gae = gae * self.bad_masks[step + 1]
+                    self.returns[step] = gae + self.value_preds[step]
+            else:
+                self.returns[-1] = next_value
+                for step in reversed(range(self.rewards.size(0))):
+                    self.returns[step] = (self.returns[step + 1] * \
+                        gamma * self.masks[step + 1] + self.rewards[step]) * self.bad_masks[step + 1] \
+                        + (1 - self.bad_masks[step + 1]) * self.value_preds[step]
+        else:
+            if use_gae:
+                self.value_preds[-1] = next_value
+                gae = 0
+                for step in reversed(range(self.rewards.size(0))):
+                    delta = self.rewards[step] + gamma * self.value_preds[
+                        step + 1] * self.masks[step +
+                                               1] - self.value_preds[step]
+                    gae = delta + gamma * gae_lambda * self.masks[step +
+                                                                  1] * gae
+                    self.returns[step] = gae + self.value_preds[step]
+            else:
+                self.returns[-1] = next_value
+                for step in reversed(range(self.rewards.size(0))):
+                    self.returns[step] = self.returns[step + 1] * \
+                        gamma * self.masks[step + 1] + self.rewards[step]
+
+    def feed_forward_generator(self,
+                               advantages,
+                               num_mini_batch=None,
+                               mini_batch_size=None):
+        num_steps, num_processes = self.rewards.size()[0:2]
+        batch_size = num_processes * num_steps
+
+        if mini_batch_size is None:
+            assert batch_size >= num_mini_batch, (
+                "PPO requires the number of processes ({}) "
+                "* number of steps ({}) = {} "
+                "to be greater than or equal to the number of PPO mini batches ({})."
+                "".format(num_processes, num_steps, num_processes * num_steps,
+                          num_mini_batch))
+            mini_batch_size = batch_size // num_mini_batch
+        sampler = BatchSampler(
+            SubsetRandomSampler(range(batch_size)),
+            mini_batch_size,
+            drop_last=True)
+        for indices in sampler:
+            obs_batch = self.obs[:-1].view(-1, *self.obs.size()[2:])[indices]
+            recurrent_hidden_states_batch = self.recurrent_hidden_states[:-1].view(
+                -1, self.recurrent_hidden_states.size(-1))[indices]
+            actions_batch = self.actions.view(-1,
+                                              self.actions.size(-1))[indices]
+            value_preds_batch = self.value_preds[:-1].view(-1, 1)[indices]
+            return_batch = self.returns[:-1].view(-1, 1)[indices]
+            masks_batch = self.masks[:-1].view(-1, 1)[indices]
+            old_action_log_probs_batch = self.action_log_probs.view(-1,
+                                                                    1)[indices]
+            if advantages is None:
+                adv_targ = None
+            else:
+                adv_targ = advantages.view(-1, 1)[indices]
+
+            yield obs_batch, recurrent_hidden_states_batch, actions_batch, \
+                value_preds_batch, return_batch, masks_batch, old_action_log_probs_batch, adv_targ
+
+    def recurrent_generator(self, advantages, num_mini_batch):
+        num_processes = self.rewards.size(1)
+        assert num_processes >= num_mini_batch, (
+            "PPO requires the number of processes ({}) "
+            "to be greater than or equal to the number of "
+            "PPO mini batches ({}).".format(num_processes, num_mini_batch))
+        num_envs_per_batch = num_processes // num_mini_batch
+        perm = torch.randperm(num_processes)
+        for start_ind in range(0, num_processes, num_envs_per_batch):
+            obs_batch = []
+            recurrent_hidden_states_batch = []
+            actions_batch = []
+            value_preds_batch = []
+            return_batch = []
+            masks_batch = []
+            old_action_log_probs_batch = []
+            adv_targ = []
+
+            for offset in range(num_envs_per_batch):
+                ind = perm[start_ind + offset]
+                obs_batch.append(self.obs[:-1, ind])
+                recurrent_hidden_states_batch.append(
+                    self.recurrent_hidden_states[0:1, ind])
+                actions_batch.append(self.actions[:, ind])
+                value_preds_batch.append(self.value_preds[:-1, ind])
+                return_batch.append(self.returns[:-1, ind])
+                masks_batch.append(self.masks[:-1, ind])
+                old_action_log_probs_batch.append(
+                    self.action_log_probs[:, ind])
+                adv_targ.append(advantages[:, ind])
+
+            T, N = self.num_steps, num_envs_per_batch
+            # These are all tensors of size (T, N, -1)
+            obs_batch = torch.stack(obs_batch, 1)
+            actions_batch = torch.stack(actions_batch, 1)
+            value_preds_batch = torch.stack(value_preds_batch, 1)
+            return_batch = torch.stack(return_batch, 1)
+            masks_batch = torch.stack(masks_batch, 1)
+            old_action_log_probs_batch = torch.stack(
+                old_action_log_probs_batch, 1)
+            adv_targ = torch.stack(adv_targ, 1)
+
+            # States is just a (N, -1) tensor
+            recurrent_hidden_states_batch = torch.stack(
+                recurrent_hidden_states_batch, 1).view(N, -1)
+
+            # Flatten the (T, N, ...) tensors to (T * N, ...)
+            obs_batch = _flatten_helper(T, N, obs_batch)
+            actions_batch = _flatten_helper(T, N, actions_batch)
+            value_preds_batch = _flatten_helper(T, N, value_preds_batch)
+            return_batch = _flatten_helper(T, N, return_batch)
+            masks_batch = _flatten_helper(T, N, masks_batch)
+            old_action_log_probs_batch = _flatten_helper(T, N, \
+                    old_action_log_probs_batch)
+            adv_targ = _flatten_helper(T, N, adv_targ)
+
+            yield obs_batch, recurrent_hidden_states_batch, actions_batch, \
+                value_preds_batch, return_batch, masks_batch, old_action_log_probs_batch, adv_targ

--- a/third-party/gala/utils.py
+++ b/third-party/gala/utils.py
@@ -1,0 +1,96 @@
+"""
+MIT License
+
+Copyright (c) 2017 Ilya Kostrikov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Taken from https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail
+and slightly modified.
+"""
+import glob
+import logging
+import math
+import os
+import sys
+
+import torch
+import torch.nn as nn
+
+from gala.envs import VecNormalize
+
+
+# Get a render function
+def get_render_func(venv):
+    if hasattr(venv, 'envs'):
+        return venv.envs[0].render
+    elif hasattr(venv, 'venv'):
+        return get_render_func(venv.venv)
+    elif hasattr(venv, 'env'):
+        return get_render_func(venv.env)
+
+    return None
+
+
+def get_vec_normalize(venv):
+    if isinstance(venv, VecNormalize):
+        return venv
+    elif hasattr(venv, 'venv'):
+        return get_vec_normalize(venv.venv)
+
+    return None
+
+
+# Necessary for my KFAC implementation.
+class AddBias(nn.Module):
+    def __init__(self, bias):
+        super(AddBias, self).__init__()
+        self._bias = nn.Parameter(bias.unsqueeze(1))
+
+    def forward(self, x):
+        if x.dim() == 2:
+            bias = self._bias.t().view(1, -1)
+        else:
+            bias = self._bias.t().view(1, -1, 1, 1)
+
+        return x + bias
+
+
+def update_linear_schedule(optimizer, epoch, total_num_epochs, initial_lr):
+    """Decreases the learning rate linearly"""
+    lr = initial_lr - (initial_lr * (epoch / float(total_num_epochs)))
+    for param_group in optimizer.param_groups:
+        param_group['lr'] = lr
+
+
+def init(module, weight_init, bias_init, gain=1):
+    weight_init(module.weight.data, gain=gain)
+    bias_init(module.bias.data)
+    return module
+
+
+def cleanup_log_dir(log_dir):
+    try:
+        os.makedirs(log_dir)
+    except OSError:
+        files = glob.glob(os.path.join(log_dir, '*.monitor.csv'))
+        for f in files:
+            os.remove(f)
+
+

--- a/train/constants.py
+++ b/train/constants.py
@@ -10,4 +10,6 @@ from os import path
 SRC_DIR = path.abspath(path.join(path.dirname(__file__), os.pardir))
 PANTHEON_ROOT = path.join(SRC_DIR, "_build/deps/pantheon")
 EXPERIMENTS_CFG = path.join(SRC_DIR, "train/experiments.yml")
+THIRD_PARTY_ROOT = path.join(SRC_DIR, "third-party")
 TORCHBEAST_ROOT = path.join(SRC_DIR, "third-party/torchbeast")
+GALA_ROOT = path.join(SRC_DIR, "third-party/gala")

--- a/train/polybeast.py
+++ b/train/polybeast.py
@@ -405,7 +405,7 @@ def train(flags):
     if not flags.disable_cuda and torch.cuda.is_available():
         logging.info("Using CUDA.")
         flags.learner_device = torch.device("cuda:0")
-        flags.actor_device = torch.device("cuda:1")
+        flags.actor_device = torch.device("cuda:0")
     else:
         logging.info("Not using CUDA.")
         flags.learner_device = torch.device("cpu")

--- a/train/polybeast.py
+++ b/train/polybeast.py
@@ -116,6 +116,23 @@ def add_args(parser):
         help="Use LSTM in agent model.",
     )
 
+    # GALA settings.
+    parser.add_argument(
+        "--num_gala_agents", default=1, type=int, help="If > 1, GALA mode is enabled."
+    )
+    parser.add_argument(
+        "--num_gala_peers",
+        type=int,
+        default=1,
+        help="Number of peers to communicate with in each iteration.",
+    )
+    parser.add_argument(
+        "--sync_freq",
+        type=int,
+        default=0,
+        help="Max amount of message staleness for local gossip.",
+    )
+
     # Loss settings.
     parser.add_argument(
         "--entropy_cost", default=0.01, type=float, help="Entropy cost/multiplier."
@@ -301,6 +318,8 @@ def learn(
     stats,
     flags,
     plogger,
+    rank=0,  # Rank of GALA agent
+    gossip_buffer=None,  # Shared buffer for GALA gossip
     lock=threading.Lock(),  # noqa: B008
 ):
     for tensors in learner_queue:
@@ -372,6 +391,11 @@ def learn(
         nn.utils.clip_grad_norm_(model.parameters(), 40.0)
         optimizer.step()
 
+        # Local-Gossip in GALA mode
+        if gossip_buffer is not None:
+            gossip_buffer.write_message(rank, model)
+            gossip_buffer.aggregate_message(rank, model)
+
         actor_model.load_state_dict(model.state_dict())
 
         episode_returns = env_outputs.episode_return[env_outputs.done]
@@ -395,7 +419,7 @@ def learn(
         lock.release()
 
 
-def train(flags):
+def train(flags, rank=0, barrier=None, device="cuda:0", gossip_buffer=None):
     if flags.xpid is None:
         flags.xpid = "torchbeast-%s" % time.strftime("%Y%m%d-%H%M%S")
     plogger = file_writer.FileWriter(
@@ -404,8 +428,8 @@ def train(flags):
 
     if not flags.disable_cuda and torch.cuda.is_available():
         logging.info("Using CUDA.")
-        flags.learner_device = torch.device("cuda:0")
-        flags.actor_device = torch.device("cuda:0")
+        flags.learner_device = torch.device(device)
+        flags.actor_device = torch.device(device)
     else:
         logging.info("Not using CUDA.")
         flags.learner_device = torch.device("cpu")
@@ -502,6 +526,8 @@ def train(flags):
                 stats,
                 flags,
                 plogger,
+                rank,
+                gossip_buffer,
             ),
         )
         for i in range(flags.num_learner_threads)
@@ -514,6 +540,11 @@ def train(flags):
         )
         for i in range(flags.num_inference_threads)
     ]
+
+    # Synchronize GALA agents before starting training
+    if barrier is not None:
+        barrier.wait()
+        logging.info("%s: barrier passed" % rank)
 
     actorpool_thread.start()
     for t in learner_threads + inference_threads:
@@ -582,7 +613,7 @@ def train(flags):
     trace_model(flags, model)
 
 
-def trace(flags):
+def trace(flags, **kwargs):
     model = Net(
         observation_shape=flags.observation_shape,
         hidden_size=flags.hidden_size,
@@ -629,7 +660,7 @@ def trace_model(flags, model):
         pickle.dump(vars(flags), f, 2)
 
 
-def test(flags):
+def test(flags, **kwargs):
     if not flags.disable_cuda and torch.cuda.is_available():
         logging.info("Using CUDA for testing.")
         flags.actor_device = torch.device("cuda:0")
@@ -707,12 +738,22 @@ def test(flags):
         t.join()
 
 
-def main(flags):
+def main(flags, rank=0, barrier=None, device="cuda:0", gossip_buffer=None):
     # We disable batching in learner as unroll lengths could different across
     # actors due to partial rollouts created by env resets.
     assert flags.batch_size == 1, "Batching in learner not supported currently"
 
+    if flags.mode == "train" and flags.num_gala_agents > 1:
+        # In GALA mode. Force single learner thread per GALA agent.
+        flags.num_learner_threads = 1
+
     flags.observation_shape = (1, 1, flags.observation_length)
+    kwargs = {
+        "rank": rank,
+        "barrier": barrier,
+        "device": device,
+        "gossip_buffer": gossip_buffer,
+    }
 
     def error_fn(flags):
         raise RuntimeError("Unsupported mode {}".format(flags.mode))
@@ -723,13 +764,13 @@ def main(flags):
     if flags.write_profiler_trace:
         logging.info("Running with profiler.")
         with torch.autograd.profiler.profile() as prof:
-            run_fn(flags)
+            run_fn(flags, **kwargs)
         filename = "chrome-%s.trace" % time.strftime("%Y%m%d-%H%M%S")
         logging.info("Writing profiler trace to '%s.gz'", filename)
         prof.export_chrome_trace(filename)
         os.system("gzip %s" % filename)
     else:
-        run_fn(flags)
+        run_fn(flags, **kwargs)
 
 
 if __name__ == "__main__":

--- a/train/train.py
+++ b/train/train.py
@@ -150,7 +150,7 @@ def run_remote(flags, train=True):
         )
         init_logdirs(flags)
 
-        # Unix domain socket path for RL server address
+        # Unix domain socket path for RL server address, one per GALA agent.
         address = "/tmp/rl_server_path_{}".format(rank)
         try:
             os.remove(address)
@@ -160,10 +160,7 @@ def run_remote(flags, train=True):
         flags.server_address = flags.address
 
         # Round-robin device assignment
-        if cuda:
-            device = "cuda:{}".format(rank % torch.cuda.device_count())
-        else:
-            device = "cpu"
+        device = "cuda:{}".format(rank % torch.cuda.device_count()) if cuda else "cpu"
 
         logging.info(
             "Starting agent {} on device {}. Mode={}, logdir={}".format(

--- a/train/train.py
+++ b/train/train.py
@@ -12,11 +12,19 @@
 import argparse
 import copy
 import logging
-import multiprocessing as mp
+import torch
+import torch.multiprocessing as mp
 import os
 import shutil
+import sys
 
 from train import polybeast, pantheon_env, common, utils
+from train.constants import THIRD_PARTY_ROOT
+
+sys.path.append(THIRD_PARTY_ROOT)
+
+from gala.gpu_gossip_buffer import GossipBuffer
+from gala.graph_manager import FullyConnectedGraph as Graph
 
 logging.basicConfig(level=logging.INFO)
 
@@ -58,37 +66,135 @@ def init_logdirs(flags):
         ), "Checkpoint {} missing in {} mode".format(flags.checkpoint, flags.mode)
 
 
+def make_gossip_buffer(flags, num_agents, mng, device):
+    """
+    Shared gossip buffer for GALA mode.
+    """
+    if num_agents <= 1:
+        return None, None
+
+    # Make topology
+    topology = []
+    for rank in range(num_agents):
+        graph = Graph(rank, num_agents, peers_per_itr=flags.num_gala_peers)
+        topology.append(graph)
+
+    # Initialize parameter buffer
+    flags.observation_shape = (1, 1, flags.observation_length)
+    model = polybeast.Net(
+        observation_shape=flags.observation_shape,
+        hidden_size=flags.hidden_size,
+        num_actions=flags.num_actions,
+        use_lstm=flags.use_lstm,
+    )
+    model.to(device)
+
+    # Keep track of local iterations since learner's last sync
+    sync_list = mng.list([0 for _ in range(num_agents)])
+    # Used to ensure proc-safe access to agents' message-buffers
+    buffer_locks = mng.list([mng.Lock() for _ in range(num_agents)])
+    # Used to signal between processes that message was read
+    read_events = mng.list(
+        [mng.list([mng.Event() for _ in range(num_agents)]) for _ in range(num_agents)]
+    )
+    # Used to signal between processes that message was written
+    write_events = mng.list(
+        [mng.list([mng.Event() for _ in range(num_agents)]) for _ in range(num_agents)]
+    )
+
+    # Need to maintain a reference to all objects in main processes
+    _references = [topology, model, buffer_locks, read_events, write_events, sync_list]
+    gossip_buffer = GossipBuffer(
+        topology,
+        model,
+        buffer_locks,
+        read_events,
+        write_events,
+        sync_list,
+        sync_freq=flags.sync_freq,
+    )
+    return gossip_buffer, _references
+
+
 def run_remote(flags, train=True):
     flags.mode = "train" if train else "test"
-    init_logdirs(flags)
-
-    # Unix domain socket path for RL server address
-    address = "/tmp/rl_server_path"
-    try:
-        os.remove(address)
-    except OSError:
-        pass
-
-    flags.address = "unix:{}".format(address)
     flags.disable_cuda = not train
     flags.cc_env_mode = "remote"
 
-    logging.info("Starting {}, logdir={}".format(flags.mode, flags.logdir))
-    polybeast_proc = mp.Process(target=polybeast.main, args=(flags,))
-    pantheon_proc = mp.Process(target=pantheon_env.main, args=(flags,))
-    polybeast_proc.start()
-    pantheon_proc.start()
+    proc_manager = mp.Manager()
+    barrier = None
+    shared_gossip_buffer = None
+    cuda = not flags.disable_cuda and torch.cuda.is_available()
+
+    num_agents = 1
+    if train and flags.num_gala_agents > 1:
+        # In GALA mode. Start multiple replicas of the polybeast-pantheon setup.
+        num_agents = flags.num_gala_agents
+        logging.info("In GALA mode, will start {} agents".format(num_agents))
+        barrier = proc_manager.Barrier(num_agents)
+
+        # Shared-gossip-buffer on GPU-0
+        device = torch.device("cuda:0" if cuda else "cpu")
+        shared_gossip_buffer, _references = make_gossip_buffer(
+            flags, num_agents, proc_manager, device
+        )
+
+    base_logdir = flags.base_logdir
+    polybeast_proc = []
+    pantheon_proc = []
+    for rank in range(num_agents):
+        flags.base_logdir = (
+            os.path.join(base_logdir, "gala_{}".format(rank))
+            if num_agents > 1
+            else base_logdir
+        )
+        init_logdirs(flags)
+
+        # Unix domain socket path for RL server address
+        address = "/tmp/rl_server_path_{}".format(rank)
+        try:
+            os.remove(address)
+        except OSError:
+            pass
+        flags.address = "unix:{}".format(address)
+        flags.server_address = flags.address
+
+        # Round-robin device assignment
+        if cuda:
+            device = "cuda:{}".format(rank % torch.cuda.device_count())
+        else:
+            device = "cpu"
+
+        logging.info(
+            "Starting agent {} on device {}. Mode={}, logdir={}".format(
+                rank, device, flags.mode, flags.logdir
+            )
+        )
+        polybeast_proc.append(
+            mp.Process(
+                target=polybeast.main,
+                args=(flags, rank, barrier, device, shared_gossip_buffer),
+                daemon=False,
+            )
+        )
+        pantheon_proc.append(
+            mp.Process(target=pantheon_env.main, args=(flags,), daemon=False)
+        )
+        polybeast_proc[rank].start()
+        pantheon_proc[rank].start()
 
     if train:
         # Training is driven by polybeast. Wait until it returns and then
         # kill pantheon_env.
-        polybeast_proc.join()
-        pantheon_proc.kill()
+        for rank in range(num_agents):
+            polybeast_proc[rank].join()
+            pantheon_proc[rank].kill()
     else:
         # Testing is driven by pantheon_env. Wait for it to join and then
         # kill polybeast.
-        pantheon_proc.join()
-        polybeast_proc.kill()
+        for rank in range(num_agents):
+            pantheon_proc[rank].join()
+            polybeast_proc[rank].kill()
 
     logging.info("Done {}".format(flags.mode))
 
@@ -104,7 +210,7 @@ def test_local(flags):
     flags.cc_env_mode = "local"
 
     logging.info("Starting local test, logdir={}".format(flags.logdir))
-    pantheon_proc = mp.Process(target=pantheon_env.main, args=(flags,))
+    pantheon_proc = mp.Process(target=pantheon_env.main, args=(flags,), daemon=False)
     pantheon_proc.start()
     pantheon_proc.join()
     logging.info("Done local test")
@@ -115,7 +221,7 @@ def trace(flags):
     init_logdirs(flags)
 
     logging.info("Tracing model from checkpoint {}".format(flags.checkpoint))
-    polybeast_proc = mp.Process(target=polybeast.main, args=(flags,))
+    polybeast_proc = mp.Process(target=polybeast.main, args=(flags,), daemon=False)
     polybeast_proc.start()
     polybeast_proc.join()
     logging.info("Done tracing to {}".format(flags.traced_model))
@@ -149,6 +255,7 @@ def main(flags):
 
 
 if __name__ == "__main__":
+    mp.set_start_method("spawn")
     parser = get_parser()
     flags = parser.parse_args()
     main(flags)


### PR DESCRIPTION
Basically what we discussed in last week's meeting. GALA-A2C is a bit tricky given that the traditional way of batching env steps in A2C (such as https://github.com/facebookresearch/gala/blob/ae5958e3fa6fc065294e383bd05cc28f92d364d1/main.py#L107) is not feasible due to inversion of control - pantheon envs send state updates to the actors as opposed to actors invoking env.step(). While synchronization of steps across actors is not possible, as @mikerabbat suggested, one could treat an entire pantheon episode (which lasts 30 seconds) as a batch.

For now though, this implementation applies GALA on top of IMPALA. Each GALA agent comprises of an IMPALA learner along with its actors, and each such agent resides entirely on a single device. The same topology as in https://github.com/facebookresearch/gala/blob/master/main.py#L171 is followed for gossip. The asynchrony between a learner and its corresponding actors within an agent is maintained as in IMPALA.

To start training, run the command at https://github.com/facebookresearch/mvfst-rl#training with an additional flag `--num_gala_agents=N`.